### PR TITLE
Add missing dependencies and regroup instructions according to the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ biocLite("TCGAbiolinksGUI")
 
 To install the package development version from Github, please, use the code below.
 ```R
-# dependencies
-devtools::install_github("BioinformaticsFMRP/TCGAbiolinks")
+library(devtools)
 source("https://bioconductor.org/biocLite.R")
-biocLite(c("pathview","clusterProfiler","ELMER"))
+
+# dependencies
 install.packages(c("shiny","readr","googleVis","shinydashboard"))
+biocLite(c("pathview","clusterProfiler","ELMER", "GO.db", "DO.db"))
+devtools::install_github("BioinformaticsFMRP/TCGAbiolinks")
 devtools::install_github("thomasp85/shinyFiles")
 devtools::install_github("ebailey78/shinyBS", ref="shinyBS3")
 devtools::install_github("daattali/shinyjs")


### PR DESCRIPTION
The original instructions on how to install the package from the source code wasn't working as `TCGAbiolinks` installation was failing without `DO.db` and `GO.db` packages. Added these to the top and also re-grouped the instructions to better distinguish the source of the dependency installation.